### PR TITLE
fix: navigate back from last page

### DIFF
--- a/src/components/Carousel/Carousel.vue
+++ b/src/components/Carousel/Carousel.vue
@@ -232,19 +232,14 @@ export default {
       }))
     },
     getCurrentPage() {
-      // Last element if there is nothing left to scroll
-      if (approximatelyEqual(
-        this.currentPos + this.wrapperVisibleWidth,
-        this.wrapperScrollWidth,
-        5
-      )) {
-        return this.slidesWidth.length - 1
-      }
-
       // Find slide closest to scroll position, with 5px approximate
-      return this.slidesWidth.findIndex(slide => {
-        return approximatelyEqual(slide.offsetLeft, this.currentPos, 5)
-      })
+      return this.slidesWidth.findIndex((slide) => {
+        return approximatelyEqual(
+          slide.offsetLeft,
+          this.currentPos,
+          slide.width / 2
+        );
+      });
     },
     setCurrentPage(index) {
       const newPage = index !== undefined ? index : this.getCurrentPage()


### PR DESCRIPTION
This is a fix to improve over customized sliders with different styles than the used here by default.

Essentially the problem here was that by just having an `epsilon` kind of `delta` value of `5` (px) to check where page are we in based on the scroll position was not something reliable for custom cases where we wanna have custom spacing or different sliders widths.

So the fix is rather simple, instead of having a 5px `epsilon` value, we use the half of the slide width to check where we really are on the slider, doing this we don't even need to check the `offset` position of the slider to see if we are on the last page and force the page to be the last one (which again, is not reliable because you end up putting the user on a page he is not really at)

You can see a sample of this working here: https://codesandbox.io/s/vue-snap-xus1hx?file=/src/components/Carousel/Carousel.vue:5458-5742
- You can navigate to the last item and start pressing the left button to navigate back, you can try changing this code to the previous code to see the error as well.